### PR TITLE
fix(docs): give IBM Plex Mono a monospace metric fallback

### DIFF
--- a/apps/docs/DESIGN.md
+++ b/apps/docs/DESIGN.md
@@ -91,8 +91,14 @@ Fontsource serves all four faces from the package's own assets: the `@import`s
 at the top of `src/styles.css` register them, and the `@theme inline` block in
 the same file assigns the roles. Metric-adjusted local fallback faces in that
 stylesheet preserve the shift-free swaps that `next/font` generated before the
-TanStack Start migration. Their overrides come from Next.js 16.3.0's metrics
-for these Google Font families.
+TanStack Start migration. The Inter and Gelasio overrides come from Next.js
+16.3.0's metrics for these Google Font families. The mono fallback stands in
+for a fixed-pitch face, so it names monospace locals instead of the
+proportional Arial `next/font` emits for every family — a proportional stand-in
+matches Plex Mono across mixed-case prose and then runs ~38% wide on the short
+uppercase apparatus labels, which is where the swap moves the layout. Those
+locals carry no `size-adjust`: every monospace face shares Plex Mono's 0.6em
+advance, so the overrides pin the vertical metrics alone.
 
 Gelasio's upright and italic latin faces preload in `src/routes/__root.tsx`
 because serif display paints on essentially every route. Inter stays
@@ -100,7 +106,7 @@ unpreloaded because its adjusted fallback stabilizes the app-wide body and
 chrome until the real face loads.
 
 IBM Plex Mono loads three explicit weights (400/500/600 — Plex Mono isn't a
-variable font), unpreloaded, swapping from its adjusted local fallback.
+variable font), unpreloaded, swapping from its monospace local fallback.
 Its `@theme inline` `--font-mono` override reroutes both the `font-mono` utility
 and every `var(--font-mono)` reference onto it in one lever.
 

--- a/apps/docs/src/styles.css
+++ b/apps/docs/src/styles.css
@@ -38,13 +38,40 @@
   size-adjust: 109.74%;
 }
 
+/* The mono fallback stands in for a fixed-pitch face, so it names monospace
+   locals — one per platform — rather than the proportional Arial next/font
+   emits for every family. A proportional stand-in tracks Plex Mono across
+   mixed-case prose and then runs ~38% wide on the short uppercase apparatus
+   labels (site nav, TOC title, version chips), which is where the swap shifts
+   the layout.
+
+   Every monospace face here advances at 0.6em, the same as Plex Mono, so the
+   overrides carry the vertical metrics alone and need no size-adjust. Those
+   metrics are what the face is for: installed monospace ascents run from 83%
+   to 104%, and pinning them means the line box is identical whichever local
+   answers. Consolas stays off the list — at 0.55em it is the one common
+   monospace that would reintroduce a width shift on the swap.
+
+   `local()` matches a full font name or a PostScript name, never a family
+   name, so entries read "Menlo-Regular" rather than "Menlo" — a family name
+   silently matches nothing. Each face is named in both forms because engines
+   differ on which they accept, and an entry that matches nothing is inert.
+   "Courier New" is the floor: its family name is also the regular face's full
+   name, so it answers everywhere the font exists.
+
+   A total miss stays safe. The face fails to load, --font-mono drops to its
+   ui-monospace tail, and the swap is still shift-free: every monospace face
+   shares the 0.6em advance, and no mono surface on the site is on
+   `line-height: normal`, so none depends on the overrides below. */
 @font-face {
   font-family: "IBM Plex Mono Fallback";
-  src: local("Arial");
-  ascent-override: 76.16%;
-  descent-override: 20.43%;
+  src:
+    local("Menlo-Regular"), local("Menlo Regular"), local("DejaVuSansMono"),
+    local("DejaVu Sans Mono Book"), local("RobotoMono-Regular"),
+    local("Roboto Mono Regular"), local("Courier New");
+  ascent-override: 102.5%;
+  descent-override: 27.5%;
   line-gap-override: 0%;
-  size-adjust: 134.59%;
 }
 
 /* Archivo SemiBold subset to the five "ZotLit" glyphs (~1 KB) — the wordmark,


### PR DESCRIPTION
Cherry-pick of aa8b9ca87 from `next`.

The mono fallback carried `next/font`'s default stand-in — Arial at `size-adjust: 134.59%`, a proportional face standing in for a fixed-pitch one. That average holds across mixed-case prose and breaks on the uppercase apparatus labels the site puts `--font-mono` on, so the site nav reflowed when the real face landed.

Measured against IBM Plex Mono:

| Text | Arial @134.59% |
| --- | --- |
| Code / mixed-case prose | +0.85% |
| Uppercase apparatus labels | **+38% mean, +52% on "Docs"** |

## Change

Name monospace locals instead. Every monospace face shares Plex Mono's 0.6em advance, so `size-adjust` goes and the overrides pin the vertical metrics alone, unscaled — `76.16% × 1.3459 = 102.5%`, the same used ascent as before. Those metrics are the point: installed monospace ascents run 83%–104%, and pinning them keeps the line box identical whichever local answers.

Consolas is deliberately excluded — at 0.55em it is the one common monospace that would reintroduce a width shift.

`local()` matches a full font name or a PostScript name, never a family name, so each face is named in both forms; an entry that matches nothing is inert. A total miss stays shift-free: `--font-mono` drops to its `ui-monospace` tail, still at 0.6em, and no mono surface on the site is on `line-height: normal`.

## Verification

Chrome over CDP at Slow 4G + 4× CPU throttling, cache cleared, warm-up navigation to remove `vite preview` cold-start cost. Both runs fetched the same 6–7 font files over the throttled link at the same LCP, so the comparison is like for like.

| Page | Before | After |
| --- | --- | --- |
| `/docs/how-to/install` | CLS 0.0048 | **CLS 0** |
| `/` | CLS 0.0053 | **CLS 0** |

The shift sources named the nav directly: `Changelog` 141→99 px, `Community` 137→99 px, `Docs` 70→53 px. With the fix those widths are pixel-identical with the mono font blocked and loaded.

Inter and Gelasio were checked and left alone — both fallbacks already match their real face (Inter within 0.17% width, identical 96.9%/24.1% vertical metrics) and contributed no shift.

`pnpm lint`, `pnpm format`, and the docs build pass on this branch.