### PR TITLE
feat(docs): show low-resolution image placeholders

### DIFF
--- a/apps/docs/src/components/docs-image.test.tsx
+++ b/apps/docs/src/components/docs-image.test.tsx
@@ -43,6 +43,9 @@ describe("DocsImage", () => {
     expect(markup).not.toContain("2048w");
     expect(markup).not.toContain("width=3512");
     expect(markup).toContain("width=1920,height=1218");
+    expect(markup).toContain(
+      "background-image:url(/cdn-cgi/image/width=24,height=15,f=auto,fit=cover/img/changelog/wikilink-citation-runs.webp)",
+    );
     expect(markup).toContain('sizes="(max-width: 768px) 100vw, 900px"');
     expect(markup).toContain('class="rounded-lg"');
   });

--- a/apps/docs/src/components/docs-image.tsx
+++ b/apps/docs/src/components/docs-image.tsx
@@ -53,6 +53,7 @@ export function DocsImage({
         (breakpoint) => breakpoint <= optimizedWidth,
       )}
       transformer={cloudflareTransform}
+      background="auto"
       operations={{
         format: "auto",
         fit: "scale-down",


### PR DESCRIPTION
Show a low-resolution background while docs images load by enabling Unpic's automatic placeholder with the existing Cloudflare transformer. Development continues to serve local image URLs.

Cherry-picks `662b46db1` from `next`. The component test verifies the 24-pixel Cloudflare background URL; both component tests, lint, and formatting pass.
